### PR TITLE
Pin markupsafe package to version before breaking change

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ setuptools.setup(
         "requests>=2.22",
         "SQLAlchemy>=1.3.13,<1.4",
         "waitress~=1.4.4",
-        "WTForms~=2.1"
+        "WTForms~=2.1",
+        "markupsafe==2.0.1"
     ],
     tests_require=test_requirements,
     extras_require={


### PR DESCRIPTION
It is required to pin markupsafe to a particular version because of a breaking change that was introduced. 

This is outlined here: https://github.com/pallets/markupsafe/issues/284
Closes https://github.com/vinogradovnet/matrix-registration/issues/1